### PR TITLE
Do not let area owners bypass ooc floodguard

### DIFF
--- a/server/client_manager.py
+++ b/server/client_manager.py
@@ -602,7 +602,7 @@ class ClientManager:
             Check if the client can use OOC or not.
             :returns: how many seconds the client must wait to use OOC
             """
-            if self.is_mod or self in self.area.owners:
+            if self.is_mod:
                 return 0
             if self.ooc_mute_time:
                 if (

--- a/server/commands/areas.py
+++ b/server/commands/areas.py
@@ -403,7 +403,7 @@ def ooc_cmd_area_kick(client, arg):
                     not client.is_mod
                     and client not in client.area.area_manager.owners
                     and client not in area.owners
-                    and area.max_players = 0
+                    and area.max_players == 0
                 ):
                     raise ArgumentError(
                         "You can't kick someone to a room that has a max players of 0!"


### PR DESCRIPTION
Currently, if you are the owner in the current area, you can bypass the floodguard completely, but OOC commands such as /g and /need send messages to the whole server and can easily be abused.